### PR TITLE
Update essentialspackages.sh.htm

### DIFF
--- a/essentialspackages-installer/usr/share/bigcontrolcenter/categories/system/essentialspackages/essentialspackages.sh.htm
+++ b/essentialspackages-installer/usr/share/bigcontrolcenter/categories/system/essentialspackages/essentialspackages.sh.htm
@@ -94,7 +94,7 @@ echo "<img src="the_internet.png" height="32" width="32">"
 echo "<INPUT TYPE=checkbox ID=proprietario NAME=proprietario VALUE=yes><LABEL FOR=proprietario>"$"Instale Google Chrome, plugin do Flash, plugin do Google Talk e Skype."
 echo "<br>""(Estes aplicativos são proprietários e por isso não podem vir pré-instalados no Kaiana, mas é recomendável que você os instale caso necessite assistir vídeos na internet, falar com amigos e familiares usando VOIP ou navegar na internet utilizando o popular navegador da Google.)" "</LABEL><br><br>"
 echo "<img src="java.png" height="32" width="32">"
-echo "<INPUT TYPE=checkbox ID=proprietario NAME=proprietario VALUE=yes><LABEL FOR=proprietario>"$"Instale o Java da Oracle (tm)." "<br>""(Alguns sites, especialmente os de bancos utilizam o java em suas aplicações e para acesso do internet bank, porém nem todos funcionam corretamente com o Java aberto sendo necessário a instalação do aplicativo proprietário nesses casos. Se esse é seu caso basta marcar esse aplicativo para instalá-lo.)" "</LABEL>"
+echo "<INPUT TYPE=checkbox ID=javaoracle NAME=javaoracle VALUE=yes><LABEL FOR=javaoracle>"$"Instale o Java da Oracle (tm)." "<br>""(Alguns sites, especialmente os de bancos utilizam o java em suas aplicações e para acesso do internet bank, porém nem todos funcionam corretamente com o Java aberto sendo necessário a instalação do aplicativo proprietário nesses casos. Se esse é seu caso basta marcar esse aplicativo para instalá-lo.)" "</LABEL>"
 
 
 #################


### PR DESCRIPTION
Corrige a instalação do Java da Oracle. O script só acionava a instalação dos pacote sugeridos pela primeira opção, mesmo marcando a segunda. Isso porque na segunda opção era usada a mesma variável "proprietario" da primeira. Eu mudei para "javaoracle", para então ficar de acordo com o script "submit.sh.htm"
